### PR TITLE
Reload RDAP details on refresh button

### DIFF
--- a/src/lib/components/rdap-details.svelte
+++ b/src/lib/components/rdap-details.svelte
@@ -54,12 +54,16 @@
 	let raw = $state<unknown>(null);
 	let showRaw = $state(false);
 
+	let currentAbortController: AbortController | null = null;
+
 	const load = async () => {
 		if (data) return;
+		const controller = new AbortController();
+		currentAbortController = controller;
 		loading = true;
 		errorMsg = null;
 		try {
-			const res = await fetch('/api/rdap');
+			const res = await fetch('/api/rdap', { signal: controller.signal });
 			const text = await res.text();
 			let body: unknown;
 			try {
@@ -78,17 +82,21 @@
 				errorMsg = msg;
 				return;
 			}
-			raw = body;
 			const parsed = RdapResponse.safeParse(body);
 			if (!parsed.success) {
 				errorMsg = 'Unexpected RDAP response shape';
 				return;
 			}
+			raw = body;
 			data = parsed.data;
 		} catch (e) {
+			if (e instanceof DOMException && e.name === 'AbortError') return;
 			errorMsg = e instanceof Error ? e.message : 'Failed to load RDAP data';
 		} finally {
-			loading = false;
+			if (currentAbortController === controller) {
+				currentAbortController = null;
+				loading = false;
+			}
 		}
 	};
 
@@ -98,6 +106,9 @@
 	};
 
 	export const reload = () => {
+		currentAbortController?.abort();
+		currentAbortController = null;
+		loading = false;
 		data = null;
 		raw = null;
 		errorMsg = null;

--- a/src/lib/components/rdap-details.svelte
+++ b/src/lib/components/rdap-details.svelte
@@ -97,6 +97,13 @@
 		if (open) load();
 	};
 
+	export const reload = () => {
+		data = null;
+		raw = null;
+		errorMsg = null;
+		if (open) load();
+	};
+
 	const eventDate = (action: string) =>
 		data?.events?.find((e) => e.eventAction === action)?.eventDate?.split('T')[0];
 
@@ -125,7 +132,7 @@
 	<Button variant="outline" class="w-full justify-between" onclick={toggle} aria-expanded={open}>
 		<span class="inline-flex items-center gap-2">
 			<Globe class="size-4" />
-			RDAP details
+			More information
 		</span>
 		<ChevronDown class={open ? 'size-4 rotate-180 transition' : 'size-4 transition'} />
 	</Button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,7 @@
 	let refreshed = $state<IpInfo | null>(null);
 	let loading = $state(false);
 	let isDark = $state(false);
+	let rdapRef = $state<ReturnType<typeof RdapDetails> | null>(null);
 
 	const ipData = $derived(loading ? undefined : (refreshed ?? data));
 
@@ -35,6 +36,7 @@
 		try {
 			const res = await fetch('/api/ip');
 			refreshed = await res.json();
+			rdapRef?.reload();
 		} finally {
 			loading = false;
 		}
@@ -91,7 +93,7 @@
 				</Button>
 			</div>
 
-			<RdapDetails />
+			<RdapDetails bind:this={rdapRef} />
 		</CardContent>
 	</Card>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * RDAP details panel now automatically refreshes in sync when IP information is updated, ensuring displayed details stay current.
  * In-flight RDAP requests are safely canceled when refreshing to avoid stale or duplicate results.
  * Toggle button label changed from "RDAP details" to "More information" for clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->